### PR TITLE
Fix getting remote port

### DIFF
--- a/pythonic.el
+++ b/pythonic.el
@@ -48,6 +48,11 @@
   (and (pythonic-remote-p)
        (s-equals-p (pythonic-remote-method) "docker")))
 
+(defun pythonic-remote-ssh-p ()
+  "Determine ssh remote virtual environment."
+  (and (pythonic-remote-p)
+       (s-equals-p (pythonic-remote-method) "ssh")))
+
 (defun pythonic-remote-vagrant-p ()
   "Determine vagrant remote virtual environment."
   (and (pythonic-remote-p)

--- a/pythonic.el
+++ b/pythonic.el
@@ -72,9 +72,7 @@
 
 (defun pythonic-remote-port ()
   "Get port of the connection to the remote python interpreter."
-  (let ((hostname (tramp-file-name-host (tramp-dissect-file-name (pythonic-aliased-path default-directory)))))
-    (when (s-contains-p "#" hostname)
-      (string-to-number (replace-regexp-in-string "\\`.*#" "" hostname)))))
+  (string-to-number (tramp-file-name-port (tramp-dissect-file-name (pythonic-aliased-path default-directory)))))
 
 
 ;;; File names.


### PR DESCRIPTION
At least for me, `tramp-file-name-host` returns hostname without the port, i.e. without `#`-part.
`tramp-file-name-port` does exactly what is needed on the other hand. Unfortunately, I wasn't able to check whether it works with vagrant (which was the first case for using `pythonic-remote-port` apparently). But I think that vagrant connection string shouldn't be different from generic ssh

What do you think about it?