### PR TITLE
Coerce result of tramp-tramp-file-p to boolean

### DIFF
--- a/pythonic.el
+++ b/pythonic.el
@@ -41,7 +41,8 @@
 
 (defun pythonic-remote-p ()
   "Determine remote virtual environment."
-  (tramp-tramp-file-p (pythonic-aliased-path default-directory)))
+  (and (tramp-tramp-file-p (pythonic-aliased-path default-directory))
+       t))
 
 (defun pythonic-remote-docker-p ()
   "Determine docker remote virtual environment."


### PR DESCRIPTION
anaconda-mode assumes that pythonic-remote-p returns either nil or t.  But before Emacs 26.1, tramp-tramp-file-p would return a number instead of t as the truthy value: https://github.com/emacs-mirror/emacs/commit/0b558b4acb8326c6f26fcde47ca85777716ae831