### PR TITLE
Add ability to set default container via dir-locals.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,3 +120,13 @@ Activate python virtual environment.  Tramp paths are supported.
 ### pythonic-deactivate
 
 Deactivate python virtual environment.
+
+
+## Project overrides with .dir-locals
+You can change the default docker file and set a default
+container to run the pythonic commands in with these dir-locals.
+
+```lisp
+((python . ((pythonic-docker-compose-filename . "local.yml")
+            (pythonic-docker-compose-container-name . "footprint"))))
+```

--- a/pythonic.el
+++ b/pythonic.el
@@ -154,6 +154,7 @@ format."
 ;;; Docker Compose.
 
 (defvar pythonic-docker-compose-filename "docker-compose.yml")
+(defvar pythonic-docker-compose-container-name nil)
 
 (defvar pythonic-read-docker-compose-file-code "
 from __future__ import print_function
@@ -208,6 +209,7 @@ print(json.dumps(yaml.safe_load(open(sys.argv[-1], 'r'))))
 
 (defun pythonic-set-docker-compose-alias ()
   "Build alias string for current docker-compose project."
+  (hack-dir-local-variables-non-file-buffer)
   (unless
       (or (tramp-tramp-file-p default-directory)
           (pythonic-has-alias-p default-directory))
@@ -220,7 +222,9 @@ print(json.dumps(yaml.safe_load(open(sys.argv[-1], 'r'))))
                ;; should appears once in the selection and all volumes
                ;; should be added to the alias list.
                (volume (if (< 1 (length volumes))
-                           (assoc (completing-read "Service: " (mapcar 'car volumes) nil t) volumes)
+                           (if pythonic-docker-compose-container-name
+                               pythonic-docker-compose-container-name
+                             (assoc (completing-read "Service: " (mapcar 'car volumes) nil t) volumes))
                          (car volumes)))
                (service (car volume))
                (sub-project (f-join project (cadr volume)))


### PR DESCRIPTION
Small change so that each time you load your project you no longer have to select your container, It will use the value you have set in (pythonic-docker-compose-container-name) if that is nil (the default) the current behaviour will be used.

let me know what you think :)