### PR TITLE
Fix docker service name returning string instead of list.

### DIFF
--- a/pythonic.el
+++ b/pythonic.el
@@ -233,9 +233,11 @@ print(json.dumps(yaml.safe_load(open(sys.argv[-1], 'r'))))
                ;; should appears once in the selection and all volumes
                ;; should be added to the alias list.
                (volume (if (< 1 (length volumes))
-                           (if pythonic-docker-compose-service-name
-                               pythonic-docker-compose-service-name
-                             (assoc (completing-read "Service: " (mapcar 'car volumes) nil t) volumes))
+                             (assoc
+                              (if pythonic-docker-compose-service-name
+                                  pythonic-docker-compose-service-name
+                                (completing-read "Service: " (mapcar 'car volumes) nil t))
+                              volumes)
                          (car volumes)))
                (service (car volume))
                (sub-project (f-join project (cadr volume)))


### PR DESCRIPTION
now Assoc's out the value from the string, finally got to look into this I implemented this previously and did it wrong, volume is not supposed to be a string.